### PR TITLE
Updating year, Instance from Ice Lake to Sapphire Rapids

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 </p> 
 
 # Intel® Optimized Cloud Modules for Terraform
-© Copyright 2024, Intel Corporation
+© Copyright 2025, Intel Corporation
 
 ## AWS Aurora PostgreSQL Module
-This code creates an Amazon Aurora instance and RDS cluster for PostgreSQL. The instance is created on an Intel Icelake instance R6i.large by default. The instance is pre-configured with parameters within the database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a database configured to run best on Intel architecture.
+This code creates an Amazon Aurora instance and RDS cluster for PostgreSQL. The instance is created on an Intel Sapphire Rapids instance R7i.large by default. The instance is pre-configured with parameters within the database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a database configured to run best on Intel architecture.
 As you configure your application's environment, choose the configurations for your infrastructure that matches your application's requirements.
 The PostgreSQL Optimizations were based off [Intel Xeon Tuning Guide](<https://www.intel.com/content/www/us/en/developer/articles/guide/open-source-database-tuning-guide-on-xeon-systems.html>)
 
@@ -16,7 +16,7 @@ The PostgreSQL Optimizations were based off [Intel Xeon Tuning Guide](<https://w
 ## AWS Aurora PostgreSQL Performance Data 
 
 <center>
-
+### The below marketing material reflects the 3rd Generation Intel® Xeon® Scalable Processor (Ice Lake). This module now runs on 4th Generation Intel® Xeon® Scalable Processor (Sapphire Rapids). Updated reading material will follow shortly. 
 #### [Handle up to 1.54x more PostgreSQL queries/second using AWS m6i instances featuring 3rd Generation Intel® Xeon® Scalable Processor (Ice Lake)](https://community.intel.com/t5/Blogs/Tech-Innovation/Cloud/Comparing-Amazon-RDS-performance-between-Intel-Graviton/post/1471648?source=MessageSyndication)
 
 <p align="center">

--- a/examples/terraform-intel-aws-postgresql-replica/README.md
+++ b/examples/terraform-intel-aws-postgresql-replica/README.md
@@ -4,11 +4,11 @@
 
 # Intel® Optimized Cloud Modules for Terraform
 
-© Copyright 2024, Intel Corporation
+© Copyright 2025, Intel Corporation
 
 ## AWS Aurora PostgreSQL Module - Read Replica Example
 
-Configuration in this examples creates an Amazon Aurora instance for PostgreSQL and creates a read replica within the same region. The instance is created on an Intel Icelake instance R6i.large by default. The instance is pre-configured with parameters within the database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a database configured to run best on Intel architecture.
+Configuration in this examples creates an Amazon Aurora instance for PostgreSQL and creates a read replica within the same region. The instance is created on an Intel Sapphire Rapids instance R7i.large by default. The instance is pre-configured with parameters within the database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a database configured to run best on Intel architecture.
 
 As you configure your application's environment, choose the configurations for your infrastructure that matches your application's requirements.
 
@@ -21,6 +21,8 @@ The PostgreSQL Optimizations were based off [Intel Xeon Tunning guides](<https:/
 By default, you will only have to pass the following variables
 ```hcl
 db_password
+subnet_id
+vpc_id
 ```
 
 variables.tf

--- a/examples/terraform-intel-aws-postgresql-replica/main.tf
+++ b/examples/terraform-intel-aws-postgresql-replica/main.tf
@@ -3,12 +3,10 @@ module "optimized-postgres-server" {
   source      = "intel/aws-aurora-postgresql/intel"
   db_password = var.db_password
   subnet_id   = "<ENTER YOUR SUBNET ID>"
-
   # Update the vpc_id below for the VPC that this module will use. Find the default vpc-id in your AWS account
   # from the AWS console or using CLI commands. In your AWS account, the vpc-id is represented as "vpc-",
   # followed by a set of alphanumeric characters. One sample representation of a vpc-id is vpc-0a6734z932p20c2m4
   vpc_id = "<YOUR-VPC-ID-HERE>"
-
 }
 
 module "optimized-postgres-server-read-replica" {

--- a/examples/terraform-intel-aws-postgresql-server/README.md
+++ b/examples/terraform-intel-aws-postgresql-server/README.md
@@ -4,11 +4,11 @@ terraform-intel-aws-postgresql  <img src="https://github.com/intel/terraform-int
 
 # Intel® Optimized Cloud Modules for Terraform
 
-© Copyright 2024, Intel Corporation
+© Copyright 2025, Intel Corporation
 
 ## AWS Aurora PostgreSQL Module - Expanded Parameters Example
 
-Configuration in this example creates an Amazon Aurora instance for PostgreSQL and optimizes the database parameter innodb_open_files. The instance is created on an Intel Icelake instance R6i.large by default. The instance uses a database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a Aurora database configured to run best on Intel architecture.
+Configuration in this example creates an Amazon Aurora instance for PostgreSQL and optimizes the database parameter innodb_open_files. The instance is created on an Intel Sapphire Rapids instance R7i.large by default. The instance uses a database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a Aurora database configured to run best on Intel architecture.
 
 As you configure your application's environment, choose the configurations for your infrastructure that matches your application's requirements.
 Double check [Aurora PostgreSQL Configuration Parameters](<https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.ParameterGroups.html>).

--- a/policies.md
+++ b/policies.md
@@ -4,7 +4,7 @@
 
 # Intel® Optimized Cloud Modules for Terraform  
 
-© Copyright 2024, Intel Corporation
+© Copyright 2025, Intel Corporation
 
 ## HashiCorp Sentinel Policies
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,13 +4,13 @@
 
 # Adjust this text to match module deployment and instance recommendations.
 
-# See policies.md, we recommend  Intel Xeon 3rd Generation Scalable processors (code-named Ice Lake)
-# Memory Optimized: db.r6i.large, db.r6i.xlarge, db.r6i.2xlarge, db.r6i.4xlarge, db.r6i.8xlarge, db.r6i.12xlarge, db.r6i.16xlarge, db.r6i.24xlarge, db.r6i.32xlarge
+# See policies.md, we recommend  Intel Xeon 4th Generation Scalable processors (code-named Sapphire Rapids)
+# Memory Optimized: db.r7i.large, db.r7i.xlarge, db.r7i.2xlarge, db.r7i.4xlarge, db.r7i.8xlarge, db.r7i.12xlarge, db.r7i.16xlarge, db.r7i.24xlarge, db.r7i.32xlarge
 
 variable "instance_class" {
   description = "The compute and memory capacity of each DB instance in the Multi-AZ DB cluster, for example db.m6g.xlarge. Not all DB instance classes are available in all AWS Regions, or for all database engines"
   type        = string
-  default     = "db.r6i.large"
+  default     = "db.r7i.large"
 }
 # all parameters dynamic
 ########################
@@ -177,7 +177,7 @@ variable "db_port" {
 variable "engine_version" {
   description = "Database engine version for AWS database instance."
   type        = string
-  default     = "14.7" #"5.7.mysql_aurora.2.11.2" // 14.5
+  default     = "14.15" #"5.7.mysql_aurora.2.11.2" // Default is 14.15
 }
 
 variable "engine" {


### PR DESCRIPTION
- Updating year from 2024 -> 2025
- Updating readme.md to have correct variables to be passed in
- Updating RDS version from 14.7 (not supported) to 14.15. Note that 16.6 is not compatible.
- Instance now running on Sapphire Rapids (4th gen), updated read mes. Ran locally, ran successfully. Need to update marketing articles.